### PR TITLE
fix: complete pnpm migration for release workflow

### DIFF
--- a/.changeset/light-frogs-swim.md
+++ b/.changeset/light-frogs-swim.md
@@ -1,0 +1,9 @@
+---
+"@mfyuu/biome-config": patch
+---
+
+- Fix pnpm migration in CI/CD workflows
+  - Add pnpm action setup to release workflow
+  - Update Node.js cache configuration from npm to pnpm
+  - Replace npm install commands with pnpm install
+  - Ensure proper dependency installation in release process

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
       # Ensure npm 11.5.1 or later is installed
@@ -37,7 +38,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: bun install
+        run: pnpm install
         env:
           CI: true # for Disable lefthook in CI
 
@@ -46,7 +47,7 @@ jobs:
         with:
           commit: "chore: release"
           title: "chore: release"
-          publish: bun run release
+          publish: pnpm release
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Instructions for GitHub Copilot Code Review: Please provide your comments and review this pull request in Japanese. -->

## Issue

N/A - Complete pnpm migration by updating release workflow

## Changes

- Add pnpm action setup in release workflow
- Update cache configuration to use pnpm instead of npm
- Update install command to use pnpm

## Verification

- [x] Tests pass successfully
- [x] No lint/type errors
- [ ] No breaking changes introduced
- [x] Changeset file created (if needed for version bump)
<!-- Changesets are required when the changes affect the published package (new features, bug fixes, breaking changes). Not needed for internal tooling, docs, or config changes. -->

## Additional Notes

This PR addresses the missing pnpm configuration in the release workflow that was overlooked during the migration from bun to pnpm. The changes ensure that the CI/CD pipeline correctly uses pnpm for dependency management and publishing.