### PR TITLE
feat: add automatic Biome scripts to package.json

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -38,6 +38,7 @@ export const initSettingsFile = async (
 	const tasks: TaskResult = {
 		dependencies: { status: "skipped" },
 		biomeConfig: { status: "skipped" },
+		scripts: { status: "skipped" },
 		settingsFile: { status: "skipped" },
 	};
 
@@ -96,7 +97,11 @@ export const initSettingsFile = async (
 	}
 
 	// Add Biome scripts to package.json
-	await addBiomeScripts(baseDir);
+	const scriptsResult = await addBiomeScripts(baseDir);
+	tasks.scripts = {
+		status: scriptsResult === "success" ? "success" : "error",
+		message: scriptsResult === "success" ? "added" : "failed",
+	};
 
 	// Determine formatter choice from CLI flags
 	let formatterChoice: "biome-only" | "with-prettier" | undefined;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,7 @@
 import { MESSAGES } from "../constants";
 import { createBiomeConfig } from "../core/biome-config";
 import { handleDependencies } from "../core/dependencies";
+import { addBiomeScripts } from "../core/scripts";
 import { showSetupSummary } from "../core/summary";
 import { createVSCodeSettings } from "../core/vscode-settings";
 import type { InitOptions, InitResult, TaskResult } from "../types/index";
@@ -93,6 +94,9 @@ export const initSettingsFile = async (
 		default:
 			biomeResult satisfies never;
 	}
+
+	// Add Biome scripts to package.json
+	await addBiomeScripts(baseDir);
 
 	// Determine formatter choice from CLI flags
 	let formatterChoice: "biome-only" | "with-prettier" | undefined;

--- a/src/core/__snapshots__/summary.test.ts.snap
+++ b/src/core/__snapshots__/summary.test.ts.snap
@@ -1,33 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`summary > showSetupSummary > should match snapshot for skipped/mixed status patterns > complex-mixed-status 1`] = `
-"  [███████░░░░░░░░░░░░░] 1/3 completed
+"  [██████████░░░░░░░░░░] 2/4 completed
 
   ✔ Dependencies (installed)
   ⚠ biome.json (already exists)
+  ✔ Scripts (added)
   ✖ .vscode/settings.json (permission denied)"
 `;
 
 exports[`summary > showSetupSummary > should match snapshot for skipped/mixed status patterns > skipped-mixed-patterns 1`] = `
-"  [░░░░░░░░░░░░░░░░░░░░] 0/3 completed
+"  [░░░░░░░░░░░░░░░░░░░░] 0/4 completed
 
   ⚠ Dependencies (skipped)
   ⚠ biome.json (skipped)
+  ⚠ Scripts (skipped)
   ⚠ .vscode/settings.json (skipped)"
 `;
 
 exports[`summary > showSetupSummary > should match snapshot for success/failure patterns > success-failure-mixed 1`] = `
-"  [█████████████░░░░░░░] 2/3 completed
+"  [███████████████░░░░░] 3/4 completed
 
   ✔ Dependencies (installed)
   ✖ biome.json (failed)
+  ✔ Scripts (added)
   ✔ .vscode/settings.json (created)"
 `;
 
 exports[`summary > showSetupSummary > should match snapshot for success/failure patterns > success-failure-patterns 1`] = `
-"  [████████████████████] 3/3 completed
+"  [████████████████████] 4/4 completed
 
   ✔ Dependencies (installed)
   ✔ biome.json (created)
+  ✔ Scripts (added)
   ✔ .vscode/settings.json (created)"
 `;

--- a/src/core/scripts.test.ts
+++ b/src/core/scripts.test.ts
@@ -1,0 +1,114 @@
+import { vol } from "memfs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { addBiomeScripts } from "./scripts";
+
+// Mock fs modules using memfs
+vi.mock("node:fs");
+vi.mock("node:fs/promises");
+
+// Mock logger
+vi.mock("../utils/logger");
+
+const execSyncMock = vi.fn();
+vi.mock("node:child_process", () => ({
+	execSync: execSyncMock,
+}));
+
+describe("scripts", () => {
+	beforeEach(() => {
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		execSyncMock.mockReset();
+	});
+
+	afterEach(() => {
+		vol.reset();
+		vi.restoreAllMocks();
+	});
+
+	describe("addBiomeScripts", () => {
+		it("should add all Biome scripts when successful", async () => {
+			vol.fromJSON({
+				"/project/package.json": JSON.stringify({
+					name: "test-project",
+					scripts: {},
+				}),
+			});
+
+			await addBiomeScripts("/project");
+
+			expect(execSyncMock).toHaveBeenCalledTimes(4);
+			expect(execSyncMock).toHaveBeenCalledWith(
+				'npm pkg set scripts.format="biome format --write"',
+				{
+					cwd: "/project",
+					stdio: "pipe",
+				},
+			);
+			expect(execSyncMock).toHaveBeenCalledWith(
+				'npm pkg set scripts.lint="biome lint"',
+				{
+					cwd: "/project",
+					stdio: "pipe",
+				},
+			);
+			expect(execSyncMock).toHaveBeenCalledWith(
+				'npm pkg set scripts.lint-fix="biome lint --write"',
+				{
+					cwd: "/project",
+					stdio: "pipe",
+				},
+			);
+			expect(execSyncMock).toHaveBeenCalledWith(
+				'npm pkg set scripts.check="biome check --write"',
+				{
+					cwd: "/project",
+					stdio: "pipe",
+				},
+			);
+		});
+
+		it("should handle execSync errors gracefully", async () => {
+			vol.fromJSON({
+				"/project/package.json": JSON.stringify({
+					name: "test-project",
+					scripts: {},
+				}),
+			});
+
+			execSyncMock.mockImplementation(() => {
+				throw new Error("Command failed");
+			});
+
+			// Should not throw
+			await expect(addBiomeScripts("/project")).resolves.not.toThrow();
+		});
+
+		it("should work with existing scripts", async () => {
+			vol.fromJSON({
+				"/project/package.json": JSON.stringify({
+					name: "test-project",
+					scripts: {
+						test: "vitest",
+						build: "tsc",
+					},
+				}),
+			});
+
+			await addBiomeScripts("/project");
+
+			expect(execSyncMock).toHaveBeenCalledTimes(4);
+		});
+
+		it("should work when package.json does not exist", async () => {
+			vol.fromJSON({
+				"/project/.gitignore": "node_modules",
+			});
+
+			// Should not throw even if package.json doesn't exist
+			await expect(addBiomeScripts("/project")).resolves.not.toThrow();
+
+			// Should still attempt to run commands
+			expect(execSyncMock).toHaveBeenCalledTimes(4);
+		});
+	});
+});

--- a/src/core/scripts.ts
+++ b/src/core/scripts.ts
@@ -1,6 +1,8 @@
 import { logger } from "../utils/logger";
 
-export const addBiomeScripts = async (baseDir: string): Promise<void> => {
+export const addBiomeScripts = async (
+	baseDir: string,
+): Promise<"success" | "error"> => {
 	try {
 		const { execSync } = await import("node:child_process");
 
@@ -19,7 +21,9 @@ export const addBiomeScripts = async (baseDir: string): Promise<void> => {
 		}
 
 		logger.success("Added Biome development scripts");
+		return "success";
 	} catch {
 		logger.warning("Failed to add Biome scripts to package.json");
+		return "error";
 	}
 };

--- a/src/core/scripts.ts
+++ b/src/core/scripts.ts
@@ -1,0 +1,25 @@
+import { logger } from "../utils/logger";
+
+export const addBiomeScripts = async (baseDir: string): Promise<void> => {
+	try {
+		const { execSync } = await import("node:child_process");
+
+		const scripts = [
+			'scripts.format="biome format --write"',
+			'scripts.lint="biome lint"',
+			'scripts.lint-fix="biome lint --write"',
+			'scripts.check="biome check --write"',
+		];
+
+		for (const script of scripts) {
+			execSync(`npm pkg set ${script}`, {
+				cwd: baseDir,
+				stdio: "pipe",
+			});
+		}
+
+		logger.success("Added Biome development scripts");
+	} catch {
+		logger.warning("Failed to add Biome scripts to package.json");
+	}
+};

--- a/src/core/summary.test.ts
+++ b/src/core/summary.test.ts
@@ -49,6 +49,7 @@ describe("summary", () => {
 			const tasks: TaskResult = {
 				dependencies: { status: "success", message: "installed" },
 				biomeConfig: { status: "success", message: "created" },
+				scripts: { status: "success", message: "added" },
 				settingsFile: { status: "success", message: "created" },
 			};
 
@@ -57,7 +58,7 @@ describe("summary", () => {
 			// Verify progress bar
 			expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("["));
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				expect.stringContaining("3/3 completed"),
+				expect.stringContaining("4/4 completed"),
 			);
 
 			// Verify each task status
@@ -79,6 +80,7 @@ describe("summary", () => {
 			const tasks: TaskResult = {
 				dependencies: { status: "success", message: "installed" },
 				biomeConfig: { status: "error", message: "failed" },
+				scripts: { status: "success", message: "added" },
 				settingsFile: { status: "success", message: "created" },
 			};
 
@@ -86,7 +88,7 @@ describe("summary", () => {
 
 			// Verify progress bar
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				expect.stringContaining("2/3 completed"),
+				expect.stringContaining("3/4 completed"),
 			);
 
 			// Verify error icon
@@ -99,6 +101,7 @@ describe("summary", () => {
 			const tasks: TaskResult = {
 				dependencies: { status: "skipped", message: "skipped" },
 				biomeConfig: { status: "skipped", message: "skipped" },
+				scripts: { status: "skipped", message: "skipped" },
 				settingsFile: { status: "skipped", message: "skipped" },
 			};
 
@@ -106,7 +109,7 @@ describe("summary", () => {
 
 			// Verify progress bar
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				expect.stringContaining("0/3 completed"),
+				expect.stringContaining("0/4 completed"),
 			);
 
 			// Verify warning icon
@@ -119,6 +122,7 @@ describe("summary", () => {
 			const tasks: TaskResult = {
 				dependencies: { status: "success", message: "installed" },
 				biomeConfig: { status: "skipped", message: "already exists" },
+				scripts: { status: "success", message: "added" },
 				settingsFile: { status: "error", message: "permission denied" },
 			};
 
@@ -126,7 +130,7 @@ describe("summary", () => {
 
 			// Verify progress bar
 			expect(consoleLogSpy).toHaveBeenCalledWith(
-				expect.stringContaining("1/3 completed"),
+				expect.stringContaining("2/4 completed"),
 			);
 
 			// Verify various icons
@@ -145,6 +149,7 @@ describe("summary", () => {
 			const tasks: TaskResult = {
 				dependencies: { status: "success" },
 				biomeConfig: { status: "success" },
+				scripts: { status: "success" },
 				settingsFile: { status: "skipped" },
 			};
 
@@ -152,7 +157,7 @@ describe("summary", () => {
 
 			// 2/3 complete = approximately 66% progress bar
 			const calls = consoleLogSpy.mock.calls.flat().join("\n");
-			expect(calls).toContain("2/3 completed");
+			expect(calls).toContain("3/4 completed");
 			// Verify progress bar is displayed
 			expect(calls).toContain("[");
 			expect(calls).toContain("]");
@@ -162,6 +167,7 @@ describe("summary", () => {
 			const tasks: TaskResult = {
 				dependencies: { status: "success", message: "installed" },
 				biomeConfig: { status: "error", message: "failed" },
+				scripts: { status: "success", message: "added" },
 				settingsFile: { status: "skipped", message: "skipped" },
 			};
 
@@ -181,6 +187,7 @@ describe("summary", () => {
 			const tasks: TaskResult = {
 				dependencies: { status: "success" },
 				biomeConfig: { status: "error" },
+				scripts: { status: "success" },
 				settingsFile: { status: "skipped" },
 			};
 
@@ -203,12 +210,14 @@ describe("summary", () => {
 			const successTasks: TaskResult = {
 				dependencies: { status: "success", message: "installed" },
 				biomeConfig: { status: "success", message: "created" },
+				scripts: { status: "success", message: "added" },
 				settingsFile: { status: "success", message: "created" },
 			};
 
 			const mixedTasks: TaskResult = {
 				dependencies: { status: "success", message: "installed" },
 				biomeConfig: { status: "error", message: "failed" },
+				scripts: { status: "success", message: "added" },
 				settingsFile: { status: "success", message: "created" },
 			};
 
@@ -231,12 +240,14 @@ describe("summary", () => {
 			const skippedTasks: TaskResult = {
 				dependencies: { status: "skipped", message: "skipped" },
 				biomeConfig: { status: "skipped", message: "skipped" },
+				scripts: { status: "skipped", message: "skipped" },
 				settingsFile: { status: "skipped", message: "skipped" },
 			};
 
 			const complexMixedTasks: TaskResult = {
 				dependencies: { status: "success", message: "installed" },
 				biomeConfig: { status: "skipped", message: "already exists" },
+				scripts: { status: "success", message: "added" },
 				settingsFile: { status: "error", message: "permission denied" },
 			};
 
@@ -259,13 +270,14 @@ describe("summary", () => {
 			const tasksAllSuccess: TaskResult = {
 				dependencies: { status: "success" },
 				biomeConfig: { status: "success" },
+				scripts: { status: "success" },
 				settingsFile: { status: "success" },
 			};
 
 			showSetupSummary(tasksAllSuccess);
 
 			const successCalls = consoleLogSpy.mock.calls.flat().join("\n");
-			expect(successCalls).toContain("3/3 completed");
+			expect(successCalls).toContain("4/4 completed");
 
 			// Reset
 			consoleLogSpy.mockClear();
@@ -274,13 +286,14 @@ describe("summary", () => {
 			const tasksAllFailed: TaskResult = {
 				dependencies: { status: "error" },
 				biomeConfig: { status: "error" },
+				scripts: { status: "error" },
 				settingsFile: { status: "error" },
 			};
 
 			showSetupSummary(tasksAllFailed);
 
 			const failedCalls = consoleLogSpy.mock.calls.flat().join("\n");
-			expect(failedCalls).toContain("0/3 completed");
+			expect(failedCalls).toContain("0/4 completed");
 		});
 	});
 });

--- a/src/core/summary.ts
+++ b/src/core/summary.ts
@@ -32,6 +32,11 @@ export const showSetupSummary = (tasks: TaskResult): void => {
 			message: tasks.biomeConfig.message,
 		},
 		{
+			name: "Scripts",
+			status: tasks.scripts.status,
+			message: tasks.scripts.message,
+		},
+		{
 			name: ".vscode/settings.json",
 			status: tasks.settingsFile.status,
 			message: tasks.settingsFile.message,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,5 +37,6 @@ type TaskResultDetail = {
 export interface TaskResult {
 	dependencies: TaskResultDetail;
 	biomeConfig: TaskResultDetail;
+	scripts: TaskResultDetail;
 	settingsFile: TaskResultDetail;
 }


### PR DESCRIPTION
<!-- Instructions for GitHub Copilot Code Review: Please provide your comments and review this pull request in Japanese. -->

## Issue

fixes #15

## Changes

- Add automatic Biome scripts to package.json during init process
- Implement `addBiomeScripts` function with npm pkg set commands
- Add comprehensive test coverage for scripts functionality
- Integrate script addition into init workflow after biome config creation
- Display scripts status in setup summary with progress tracking
- Scripts include: format, lint, lint-fix, and check commands

## Verification

- [x] Tests pass successfully
- [x] No lint/type errors
- [x] No breaking changes introduced
- [ ] Changeset file created (if needed for version bump)

## Additional Notes

This PR adds automatic package.json scripts setup to the starter wizard. The implementation:

1. **Core functionality**: Uses npm pkg set to reliably add 4 Biome development scripts
2. **Error handling**: Gracefully handles failures and logs appropriate messages
3. **UI integration**: Shows scripts status in the 4-task progress summary
4. **Testing**: Comprehensive test coverage including edge cases and error scenarios

The scripts are added after biome.json creation but before VS Code settings, ensuring the development workflow is fully configured when the wizard completes.