### PR TITLE
docs: update README to match CLI implementation and add Japanese support

### DIFF
--- a/.changeset/khaki-bikes-care.md
+++ b/.changeset/khaki-bikes-care.md
@@ -1,0 +1,10 @@
+---
+"@mfyuu/biome-config": patch
+---
+
+- Update documentation to match actual CLI implementation and add Japanese support
+  - Fix outdated "This command will" section with complete feature list
+  - Add missing CLI features: package.json scripts, Lefthook integration, formatter choices
+  - Create comprehensive Japanese documentation (README.ja.md)
+  - Add language switcher between English and Japanese versions
+  - Keep technical section headers in English for developer consistency

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,120 @@
+# @mfyuu/biome-config
+
+[English](./README.md) | Japanese
+
+[@mfyuu](https://github.com/mfyuu)による JavaScript/TypeScript プロジェクト用の共有可能な Biome 設定パッケージです。
+
+プロジェクトタイプに応じて、base、React、Next.js の 3 つの設定から選択できます。
+
+## Usage
+
+### Starter Wizard (Recommended)
+
+プロジェクトに Biome をセットアップする最も簡単な方法は、インタラクティブな CLI ウィザードを使用することです：
+
+```bash
+npx @mfyuu/biome-config
+```
+
+このコマンドは以下を実行します：
+
+- プロジェクトタイプの検出（base、React、または Next.js）
+- 必要な依存関係のインストール（`@biomejs/biome` と `@mfyuu/biome-config`）
+- 適切な設定で `biome.json` または `biome.jsonc` を作成
+- `package.json` に Biome スクリプトを追加（`format`、`lint`、`lint-fix`、`check`）
+- `.vscode/settings.json` で VS Code 統合をセットアップ
+  - Biome のみのフォーマットか、Markdown ファイル用の Biome + Prettier かを選択
+- オプションで Git hooks 自動化のための Lefthook 統合
+  - lefthook 設定ファイルの作成
+  - 自動 Git hooks インストール用の `prepare` スクリプトの追加
+
+利用可能なすべてのオプションを確認するには：
+
+```bash
+npx @mfyuu/biome-config --help
+```
+
+### Manual Setup
+
+手動でセットアップしたい場合：
+
+1. 必要なパッケージをインストール：
+
+```bash
+npm i -D @biomejs/biome @mfyuu/biome-config
+```
+
+2. プロジェクトルートに `biome.json` または `biome.jsonc` を作成：
+
+#### Base Configuration (Node.js/TypeScript プロジェクト)
+
+```json
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": ["@mfyuu/biome-config/base"]
+}
+```
+
+#### React Configuration
+
+```json
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": ["@mfyuu/biome-config/react"]
+}
+```
+
+#### Next.js Configuration
+
+```json
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": ["@mfyuu/biome-config/next"]
+}
+```
+
+> [!note]
+> 物理ファイルの解決に問題がある場合は、このサイトで公開されているものを使用できます：
+>
+> ```json
+> "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json"
+> ```
+
+## Configuration Contents
+
+### base
+
+- 基本的なフォーマット設定（インデント、改行など）
+- 一般的な TypeScript/JavaScript lint ルール
+- 一般的なベストプラクティス
+
+### react
+
+- base の全設定を継承
+- React/JSX 固有のルール
+- Hooks 関連のルール
+- アクセシビリティルール
+
+### next
+
+- react の全設定を継承
+- Next.js 固有のファイルパターン除外
+- App Router と Pages Router の両方をサポート
+
+## Customization
+
+`biome.json` または `biome.jsonc` にカスタム設定を追加することで、継承した設定を上書きできます：
+
+```json
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": ["@mfyuu/biome-config/base"],
+  "formatter": {
+    "indentStyle": "space"
+  }
+}
+```
+
+## License
+
+[MIT](./LICENSE) License © 2025-PRESENT [Kazuya Suzuki](https://github.com/mfyuu)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @mfyuu/biome-config
 
+English | [Japanese](./README.ja.md)
+
 Shareable Biome configuration package for JavaScript/TypeScript projects by [@mfyuu](https://github.com/mfyuu).
 
 Choose from three configurations based on your project type: base, React, or Next.js.
@@ -19,7 +21,12 @@ This command will:
 - Detect your project type (base, React, or Next.js)
 - Install required dependencies (`@biomejs/biome` and `@mfyuu/biome-config`)
 - Create `biome.json` or `biome.jsonc` with the appropriate configuration
+- Add Biome scripts to your `package.json` (`format`, `lint`, `lint-fix`, `check`)
 - Set up VS Code integration with `.vscode/settings.json`
+  - Choose between Biome-only formatting or Biome with Prettier for Markdown files
+- Optionally integrate Lefthook for Git hooks automation
+  - Creates lefthook configuration file
+  - Adds `prepare` script for automatic Git hooks installation
 
 For all available options:
 


### PR DESCRIPTION
<!-- Instructions for GitHub Copilot Code Review: Please provide your comments and review this pull request in Japanese. -->

## Issue

N/A - Update documentation to accurately reflect CLI implementation and add Japanese language support

## Changes

- Fix outdated "This command will" section in README.md to match actual CLI implementation
- Add missing CLI features documentation: package.json scripts, Lefthook integration, formatter choices
- Create comprehensive Japanese documentation (README.ja.md)
- Add language switcher between English and Japanese versions
- Keep technical section headers in English for developer consistency
- Create changeset for patch version bump

## Verification

- [x] Tests pass successfully
- [x] No lint/type errors
- [x] No breaking changes introduced
- [x] Changeset file created (if needed for version bump)

## Additional Notes

This PR addresses the discrepancy between the CLI's actual functionality and its documentation. The README previously only mentioned basic features, but the CLI actually provides many more capabilities like script installation, VS Code settings setup, and Lefthook integration. The Japanese documentation maintains the same structure while providing localized content for Japanese-speaking developers.