### PR TITLE
chore: add lefthook configuration with pre-commit and pre-push hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  commands:
+    sort-package-json:
+      glob: "package.json"
+      run: pnpm exec sort-package-json {staged_files}
+      stage_fixed: true
+    check:
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      run: pnpm exec biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      stage_fixed: true
+pre-push:
+  commands:
+    check:
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      run: pnpm exec biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,58 @@
 {
 	"name": "@mfyuu/biome-config",
 	"version": "1.3.4",
-	"author": "mfyuu",
+	"description": "Shareable Biome configuration for JavaScript/TypeScript projects",
+	"keywords": [
+		"biome",
+		"config",
+		"linter",
+		"formatter",
+		"javascript",
+		"typescript",
+		"react",
+		"nextjs"
+	],
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/mfyuu/biome-config.git"
+	},
+	"license": "MIT",
+	"author": "mfyuu",
+	"type": "module",
+	"exports": {
+		"./base": "./configs/base.json",
+		"./react": "./configs/react.json",
+		"./next": "./configs/next.json"
+	},
+	"bin": {
+		"biome-config": "./dist/cli.js"
+	},
+	"files": [
+		"configs",
+		"dist",
+		"templates",
+		"README.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"build": "tsdown",
+		"changeset": "changeset",
+		"check": "biome check --write .",
+		"dev": "tsx src/cli.ts",
+		"format": "biome format --write .",
+		"preinstall": "npx only-allow pnpm",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint --write .",
+		"prepare": "lefthook install",
+		"prepublishOnly": "pnpm run build",
+		"release": "changeset publish",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:update": "vitest run --update",
+		"test:watch": "vitest watch",
+		"typecheck": "tsc --noEmit",
+		"version": "changeset version",
+		"watch": "tsdown --watch"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.4",
@@ -17,11 +65,13 @@
 		"commander": "^14.0.0",
 		"cross-spawn": "^7.0.6",
 		"kleur": "^4.1.5",
+		"lefthook": "^1.12.4",
 		"log-symbols": "^7.0.1",
 		"memfs": "^4.38.1",
 		"ora": "^8.2.0",
 		"prettier": "^3.6.2",
 		"prompts": "^2.4.2",
+		"sort-package-json": "^3.4.0",
 		"tsdown": "^0.15.0",
 		"tsx": "^4.20.4",
 		"typescript": "^5.9.2",
@@ -30,61 +80,15 @@
 	"peerDependencies": {
 		"@biomejs/biome": ">=2.0.0"
 	},
-	"exports": {
-		"./base": "./configs/base.json",
-		"./react": "./configs/react.json",
-		"./next": "./configs/next.json"
-	},
-	"bin": {
-		"biome-config": "./dist/cli.js"
-	},
-	"description": "Shareable Biome configuration for JavaScript/TypeScript projects",
-	"files": [
-		"configs",
-		"dist",
-		"templates",
-		"README.md",
-		"LICENSE"
-	],
-	"keywords": [
-		"biome",
-		"config",
-		"linter",
-		"formatter",
-		"javascript",
-		"typescript",
-		"react",
-		"nextjs"
-	],
-	"license": "MIT",
 	"peerDependenciesMeta": {
 		"@biomejs/biome": {
 			"optional": false
 		}
 	},
+	"packageManager": "pnpm@10.15.1",
 	"publishConfig": {
 		"access": "public"
 	},
-	"scripts": {
-		"build": "tsdown",
-		"dev": "tsx src/cli.ts",
-		"watch": "tsdown --watch",
-		"format": "biome format --write .",
-		"lint": "biome lint .",
-		"lint:fix": "biome lint --write .",
-		"check": "biome check --write .",
-		"typecheck": "tsc --noEmit",
-		"changeset": "changeset",
-		"release": "changeset publish",
-		"version": "changeset version",
-		"prepublishOnly": "pnpm run build",
-		"test": "vitest run",
-		"test:watch": "vitest watch",
-		"test:update": "vitest run --update",
-		"test:coverage": "vitest run --coverage"
-	},
-	"type": "module",
-	"packageManager": "pnpm@10.15.1",
 	"pnpm": {
 		"overrides": {
 			"rolldown": "1.0.0-beta.35"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      lefthook:
+        specifier: ^1.12.4
+        version: 1.12.4
       log-symbols:
         specifier: ^7.0.1
         version: 7.0.1
@@ -56,6 +59,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      sort-package-json:
+        specifier: ^3.4.0
+        version: 3.4.0
       tsdown:
         specifier: ^0.15.0
         version: 0.15.0(typescript@5.9.2)
@@ -864,6 +870,14 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  detect-indent@7.0.1:
+    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
+    engines: {node: '>=12.20'}
+
+  detect-newline@4.0.1:
+    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
@@ -976,6 +990,9 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  git-hooks-list@4.1.1:
+    resolution: {integrity: sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1043,6 +1060,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -1107,6 +1128,60 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lefthook-darwin-arm64@1.12.4:
+    resolution: {integrity: sha512-/eBd9GnBS9Js2ZsHzipj2cV8siFex/g6MgBSeIxsHBJNkQFq4O42ItWxUir5Q43zFvZCjGizBlhklbmubGOZfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.12.4:
+    resolution: {integrity: sha512-WDO0oR3pIAIBTZtn4/4dC0GRyrfJtPGckYbqshpH4Fkuxyy7nRGy3su+uY8kiiVYLy/nvELY2eoqnT1Rp4njFQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.12.4:
+    resolution: {integrity: sha512-/VNBWQvAsLuVilS7JB+pufTjuoj06Oz5YdGWUCo6u2XCKZ6UHzwDtGDJ0+3JQMSg8613gHmAdkGoByKjxqZSkQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.12.4:
+    resolution: {integrity: sha512-bY6klVVeBoiQEimb/z5TC5IFyczak9VOVQ8b+S/QAy+tvKo9TY6FdGwy7yxgoqTzfEkirDQxVOkalQsM/11xsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.12.4:
+    resolution: {integrity: sha512-iU+tPCNcX1pztk5Zjs02+sOnjZj9kCrLn6pg954WMr9dZTIaEBljRV+ybBP/5zLlv2wfv5HFBDKDKNRYjOVF+A==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.12.4:
+    resolution: {integrity: sha512-IXYUSBYetftYmdii2aGIjv7kxO2m+jTYjaEoldtCDcXAPz/yV78Xx2WzY/LYNJsJ1vzbUhBqVOeRCHCwLXusTQ==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.12.4:
+    resolution: {integrity: sha512-3DFLbqAlAeoqo//PE20NcGKJzBqAMbS/roPvaJ9DYA95MSywMig2jxyDoZbBhyP/J/iuFO3op7emtwgwousckA==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.12.4:
+    resolution: {integrity: sha512-Nlxn3lXHK3hRDL5bP5W6+LleE9CRIc6GJ84xTo9EPwI40utsM8olAm+pFFRnE9szkHvQTkXwoBhqi2C5laxoGQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.12.4:
+    resolution: {integrity: sha512-tWOfrTC9GNheaFXFt49G5nbBUYLqd2NBb5XW97dSLO/lU81cvuvRsMKZFBrq48LvByT7PLwEuibMuO1TminhHA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.12.4:
+    resolution: {integrity: sha512-3B295z3tdcdDrKrY98b/cSm4Elb/TXWMVQuH2xW15CJp9QY6jsgRpFJyBdyz4ggrPFhNUVnLKCpm6/saqeZWHA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.12.4:
+    resolution: {integrity: sha512-VhTFYGT55pD2hytjcn6Lckb0tCbG1Cke6rszTWVQVJpnJZ0EqQW+Pl+JYQLlruR8MO4RGFVU0UBUw17/g9TYxA==}
+    hasBin: true
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -1363,6 +1438,14 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sort-object-keys@1.1.3:
+    resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
+
+  sort-package-json@3.4.0:
+    resolution: {integrity: sha512-97oFRRMM2/Js4oEA9LJhjyMlde+2ewpZQf53pgue27UkbEXfHJnDzHlUxQ/DWUkzqmp7DFwJp8D+wi/TYeQhpA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2367,6 +2450,10 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
+  detect-indent@7.0.1: {}
+
+  detect-newline@4.0.1: {}
+
   diff@8.0.2: {}
 
   dir-glob@3.0.1:
@@ -2484,6 +2571,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  git-hooks-list@4.1.1: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -2539,6 +2628,8 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -2597,6 +2688,49 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  lefthook-darwin-arm64@1.12.4:
+    optional: true
+
+  lefthook-darwin-x64@1.12.4:
+    optional: true
+
+  lefthook-freebsd-arm64@1.12.4:
+    optional: true
+
+  lefthook-freebsd-x64@1.12.4:
+    optional: true
+
+  lefthook-linux-arm64@1.12.4:
+    optional: true
+
+  lefthook-linux-x64@1.12.4:
+    optional: true
+
+  lefthook-openbsd-arm64@1.12.4:
+    optional: true
+
+  lefthook-openbsd-x64@1.12.4:
+    optional: true
+
+  lefthook-windows-arm64@1.12.4:
+    optional: true
+
+  lefthook-windows-x64@1.12.4:
+    optional: true
+
+  lefthook@1.12.4:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.12.4
+      lefthook-darwin-x64: 1.12.4
+      lefthook-freebsd-arm64: 1.12.4
+      lefthook-freebsd-x64: 1.12.4
+      lefthook-linux-arm64: 1.12.4
+      lefthook-linux-x64: 1.12.4
+      lefthook-openbsd-arm64: 1.12.4
+      lefthook-openbsd-x64: 1.12.4
+      lefthook-windows-arm64: 1.12.4
+      lefthook-windows-x64: 1.12.4
 
   locate-path@5.0.0:
     dependencies:
@@ -2854,6 +2988,18 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
+
+  sort-object-keys@1.1.3: {}
+
+  sort-package-json@3.4.0:
+    dependencies:
+      detect-indent: 7.0.1
+      detect-newline: 4.0.1
+      git-hooks-list: 4.1.1
+      is-plain-obj: 4.1.0
+      semver: 7.7.2
+      sort-object-keys: 1.1.3
+      tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
<!-- Instructions for GitHub Copilot Code Review: Please provide your comments and review this pull request in Japanese. -->

## Issue

N/A - Add lefthook configuration for automated code quality checks

## Changes

- Add lefthook.yml configuration file with pre-commit and pre-push hooks
- Configure pre-commit hooks to run sort-package-json and biome check on staged files
- Configure pre-push hooks to validate code quality before pushing
- Add lefthook and sort-package-json as dev dependencies
- Add prepare script to automatically install lefthook hooks
- Sort package.json fields according to conventional order

## Verification

- [x] Tests pass successfully
- [x] No lint/type errors
- [x] No breaking changes introduced
- [x] Changeset file created (if needed for version bump)

## Additional Notes

This change adds automated code quality checks through lefthook git hooks:
- Pre-commit hooks ensure code is formatted and linted before commits
- Pre-push hooks prevent pushing code with quality issues
- The prepare script automatically installs hooks when dependencies are installed